### PR TITLE
Security improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ COPY internal/ ./internal/
 RUN go build -o /openfaas-sqs-connector -v ./cmd/main.go
 
 FROM gcr.io/distroless/base
+USER nobody:nobody
+WORKDIR /
 COPY --from=builder /openfaas-sqs-connector /openfaas-sqs-connector
 ENTRYPOINT ["/openfaas-sqs-connector"]
 CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.7 AS builder
+FROM golang:1.13.0-buster AS builder
 ENV GO111MODULE on
 WORKDIR /go/src/github.com/form3tech-oss/openfaas-sqs-connector
 COPY go.mod go.sum ./

--- a/deploy/kubernetes/openfaas-sqs-connector-dep.yaml
+++ b/deploy/kubernetes/openfaas-sqs-connector-dep.yaml
@@ -1,3 +1,10 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openfaas-sqs-connector
+  namespace: openfaas
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -55,6 +62,7 @@ spec:
           mountPath: /secret
       securityContext:
         fsGroup: 65534
+      serviceAccountName: openfaas-sqs-connector
       volumes:
       - name: basic-auth
         secret:

--- a/deploy/kubernetes/openfaas-sqs-connector-dep.yaml
+++ b/deploy/kubernetes/openfaas-sqs-connector-dep.yaml
@@ -40,10 +40,21 @@ spec:
           value: "true"
         - name: secret_mount_path
           value: /secret
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
         volumeMounts:
         - name: basic-auth
           readOnly: true
           mountPath: /secret
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: basic-auth
         secret:


### PR DESCRIPTION
- [x] Use Go 1.13.0.
- [x] Run as `nobody:nobody`.
- [x] Use a dedicated service account.