### PR TITLE
Allow for specifying the AWS SQS endpoint URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,13 @@ $ helm upgrade --install openfaas-sqs-connector openfaas-sqs-connector/openfaas-
 
 Please check [`values.yaml`](https://github.com/form3tech-oss/openfaas-sqs-connector/blob/master/helm/openfaas-sqs-connector/values.yaml) for details on how to tweak the installation. 
 
-### Kubernetes
+### `kubectl`
 
 To install `openfaas-sqs-connector` using `kubectl`, edit `./deploy/kubernetes/openfaas-sqs-connector-dep.yaml` as required in order to set appropriate values for each flag:
 
 Flag&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Description | Default
 ---- | ----------- | -------
+`--endpoint` | The AWS SQS endpoint to use. Useful when using [`elasticmq`](https://github.com/softwaremill/elasticmq) for local development. | `""`
 `--log-level` | The log level to use. | `info`
 `--max-number-of-messages` | The maximum number of messages to return from the AWS SQS queue per iteration. | `1`
 `--max-wait-time` | The maximum amount of time (in seconds) to wait for messages to be returned from the AWS SQS queue per iteration. | `1`

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -29,6 +29,7 @@ import (
 
 func main() {
 	// Parse command-line flags.
+	endpoint := flag.String("endpoint", "", "the aws sqs endpoint url to use")
 	logLevel := flag.String("log-level", "info", "the log level to use")
 	maxNumberOfMessages := flag.Int64("max-number-of-messages", 1, "the maximum number of messages to return from the aws sqs queue per iteration")
 	maxWaitTime := flag.Int64("max-wait-time", 1, "the maximum amount of time (in seconds) to wait for messages to be returned from the aws sqs queue per iteration")
@@ -48,13 +49,13 @@ func main() {
 
 	// Make sure that all required flags have been provided.
 	if *region == "" {
-		log.Fatal("--aws-region must be provided")
+		log.Fatal("--region must be provided")
 	}
 	if *queueURL == "" {
-		log.Fatal("--aws-sqs-queue-url must be provided")
+		log.Fatal("--queue-url must be provided")
 	}
 	if *openfaasGatewayURL == "" {
-		log.Fatal("--gateway-url must be provided")
+		log.Fatal("--openfaas-gateway-url must be provided")
 	}
 
 	// Initialize the controller.
@@ -68,6 +69,7 @@ func main() {
 
 	// Initialize the AWS SQS client.
 	awsSession, err := session.NewSession(&aws.Config{
+		Endpoint:                      endpoint,
 		CredentialsChainVerboseErrors: aws.Bool(log.IsLevelEnabled(log.DebugLevel)),
 		Region:                        region,
 	})

--- a/helm/openfaas-sqs-connector/Chart.yaml
+++ b/helm/openfaas-sqs-connector/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 1.0.1
+appVersion: 1.0.2
 description: An OpenFaaS connector for AWS SQS.
 name: openfaas-sqs-connector
-version: 1.0.2
+version: 1.1.0
 home: https://github.com/form3tech-oss/openfaas-sqs-connector
 sources:
   - https://github.com/form3tech-oss/openfaas-sqs-connector

--- a/helm/openfaas-sqs-connector/templates/deployment.yaml
+++ b/helm/openfaas-sqs-connector/templates/deployment.yaml
@@ -22,6 +22,8 @@ spec:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         args:
+        - --endpoint
+        - "{{ .Values.endpoint }}"
         - --log-level
         - "{{ .Values.logLevel }}"
         - --max-number-of-messages

--- a/helm/openfaas-sqs-connector/values.yaml
+++ b/helm/openfaas-sqs-connector/values.yaml
@@ -1,6 +1,7 @@
+endpoint: ""
 image:
   repository: form3tech/openfaas-sqs-connector
-  tag: 1.0.1
+  tag: 1.1.0
 logLevel: info
 maxNumberOfMessages: 1
 maxWaitTime: 1


### PR DESCRIPTION
This is useful when using [`elasticmq`](https://github.com/softwaremill/elasticmq) for local development.